### PR TITLE
add newline before list in functions-and-methods

### DIFF
--- a/features/functions-and-methods/README.md
+++ b/features/functions-and-methods/README.md
@@ -20,6 +20,7 @@ for any operation that is clearly associated with a particular
 type.
 
 Methods have numerous advantages over functions:
+
 * They do not need to be imported or qualified to be used: all you
   need is a value of the appropriate type.
 * Their invocation performs autoborrowing (including mutable borrows).


### PR DESCRIPTION
The current version of hoedown treats lists interrupting paragraphs in the Markdown.pl style rather than CommonMark, so a newline is needed for the list to be rendered properly.